### PR TITLE
Add Token parameter to operation header

### DIFF
--- a/src/SwiftLink.Presentation/Filters/SwaggerAuthenticationFilter.cs
+++ b/src/SwiftLink.Presentation/Filters/SwaggerAuthenticationFilter.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace SwiftLink.Presentation.Filters;
+
+/// <summary>
+/// Adds a custom parameter named “Token” to the header of every operation,
+/// which requires the user to enter their subscription key.
+/// </summary>
+public class SwaggerAuthenticationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Parameters ??= new List<OpenApiParameter>();
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Token",
+            In = ParameterLocation.Header,
+            Description = "Enter your subscription key"
+        });
+    }
+}

--- a/src/SwiftLink.Presentation/Program.cs
+++ b/src/SwiftLink.Presentation/Program.cs
@@ -9,6 +9,7 @@ using SwiftLink.Application.Common.Interfaces;
 using SwiftLink.Infrastructure;
 using SwiftLink.Infrastructure.Persistence.Context;
 using SwiftLink.Presentation.Extensions;
+using SwiftLink.Presentation.Filters;
 using SwiftLink.Presentation.Middleware;
 using SwiftLink.Presentation.Services;
 using SwiftLink.Shared;
@@ -58,13 +59,15 @@ var builder = WebApplication.CreateBuilder(args);
         options.Port = ushort.Parse(builder.Configuration["AppSettings:DefaultPrometheusPort"]);
     });
 
-    builder.Services.AddSwaggerGen(c =>
+    builder.Services.AddSwaggerGen(options =>
     {
-        c.SwaggerDoc("v1", new OpenApiInfo
+        options.SwaggerDoc("v1", new OpenApiInfo
         {
             Title = "SwiftLink",
             Version = "v1",
         });
+
+        options.OperationFilter<SwaggerAuthenticationFilter>();
     });
 }
 


### PR DESCRIPTION
This change implements the SwaggerAuthenticationFilter class that adds a custom parameter named Token to the header of every operation. This parameter requires the user to enter their subscription key for authentication purposes.