### PR TITLE
Add conditional validation for BackHalf property

### DIFF
--- a/src/SwiftLink.Application/UseCases/Links/Commands/GenerateShortCode/GenerateShortCodeValidator.cs
+++ b/src/SwiftLink.Application/UseCases/Links/Commands/GenerateShortCode/GenerateShortCodeValidator.cs
@@ -17,7 +17,7 @@ public class GenerateShortCodeValidator : AbstractValidator<GenerateShortCodeCom
 
         RuleFor(x => x.BackHalf)
             .MaximumLength(16).WithMessage(LinkMessages.BackHalfLength.Message)
-            .Must(BeAValidCharacters).WithMessage(LinkMessages.BackHalfInvalidFormat.Message)
+            .Must(BeAValidCharacters).WithMessage(LinkMessages.BackHalfInvalidFormat.Message).When(x => x.BackHalf is not null)
             .MustAsync(BeAValidBackHalf).WithMessage(LinkMessages.BackHalfIsExist.Message);
 
         RuleFor(x => x.ExpirationDate)


### PR DESCRIPTION
Resolve exception for nullable BackHalf property

This update addresses an issue where null values submitted for the BackHalf property were triggering an exception due to the validation rule. The validation logic has been modified to only apply when the BackHalf property is not null, ensuring that the application can gracefully handle null inputs without causing unintended exceptions.