### PR TITLE
Add new Method to Result

### DIFF
--- a/src/SwiftLink.Application/UseCases/Links/Queries/GetByGroupName/GetLinkByGroupNameQueryHandler.cs
+++ b/src/SwiftLink.Application/UseCases/Links/Queries/GetByGroupName/GetLinkByGroupNameQueryHandler.cs
@@ -7,9 +7,8 @@ public class GetLinkByGroupNameQueryHandler(IApplicationDbContext dbContext) : I
 {
     private readonly IApplicationDbContext _dbContext = dbContext;
 
-    public async Task<Result<IEnumerable<LinksDto>>> Handle(GetLinkByGroupNameQuery request, CancellationToken cancellationToken)
-    {
-        IEnumerable<LinksDto> result = await _dbContext.Set<Link>()
+    public async Task<Result<IEnumerable<LinksDto>>> Handle(GetLinkByGroupNameQuery request, CancellationToken cancellationToken) =>
+     await Result<IEnumerable<LinksDto>>.Validation(async ()=> await  _dbContext.Set<Link>()
                                .Where(x => x.GroupName == request.GroupName)
                                .AsNoTracking()
                                .Select(x => new LinksDto
@@ -23,7 +22,5 @@ public class GetLinkByGroupNameQueryHandler(IApplicationDbContext dbContext) : I
                                    IsDisabled = x.IsDisabled,
                                    LinkdId = x.Id
                                })
-                               .ToListAsync(cancellationToken);
-        return Result.Success(result);
-    }
+                               .ToListAsync(cancellationToken));
 }

--- a/src/SwiftLink.Shared/Result/Result.cs
+++ b/src/SwiftLink.Shared/Result/Result.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace SwiftLink.Shared;
 
@@ -45,4 +46,17 @@ public class Result<T> : Result
 
     public static new Result<T> Failure(Error error) 
         => new(false, default!, error);
+
+    public static async Task<Result<T>> Validation(Func<Task<T>> func)
+    {
+        try
+        {
+            var result = await func();
+            return Success(result);
+        }
+        catch (Exception ex)
+        {
+            return Failure(Error.Exception(ErrorType.None.ToString(), ex.Message));
+        }
+    }
 }


### PR DESCRIPTION
The validation method was added to the result.
This method is used when you want to return data directly without any condition to check for runtime error or other such errors.