### PR TITLE
Fix typo in serilog configuration

### DIFF
--- a/src/SwiftLink.Presentation/appsettings.Development.json
+++ b/src/SwiftLink.Presentation/appsettings.Development.json
@@ -8,7 +8,7 @@
       "RedisCacheUrl": "127.0.0.1:6379",
       "SlidingExpirationHour": 5
     },
-    "LoggingBehavior": "enable",
+    "LoggingBehavior": "enable"
   },
   "Serilog": {
     "Using": [
@@ -29,10 +29,10 @@
       {
         "Name": "File",
         "Args": {
-          "path": "/logs/log-.txt",
-          "rolingInterval": "Day",
-          "roleOnFileSizeLimit": true,
-          "formater": "Serilog.Formatting.Json.JsonFormatter"
+          "path": "logs/log-.txt",
+          "rollingInterval": "Day",
+          "rollOnFileSizeLimit": true,
+          "formatter": "Serilog.Formatting.Json.JsonFormatter"
         }
       }
     ],

--- a/src/SwiftLink.Presentation/appsettings.json
+++ b/src/SwiftLink.Presentation/appsettings.json
@@ -29,10 +29,10 @@
       {
         "Name": "File",
         "Args": {
-          "path": "/logs/log-.txt",
-          "rolingInterval": "Day",
-          "roleOnFileSizeLimit": true,
-          "formater": "Serilog.Formatting.Compact.CompactJsonFormatter"
+          "path": "logs/log-.txt",
+          "rollingInterval": "Day",
+          "rollOnFileSizeLimit": true,
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter"
         }
       }
     ],


### PR DESCRIPTION
## Pull Request Title
**Fix typos in Serilog configurations for both development and production environments**

## Description
This pull request addresses typos in the Serilog configuration within both `appsettings.Development.json` and `appsettings.json` files. The changes ensure that the configuration keys are correctly spelled and paths are correctly formatted. Specifically:

- Corrected `rolingInterval` to `rollingInterval`
- Corrected `roleOnFileSizeLimit` to `rollOnFileSizeLimit`
- Corrected `formater` to `formatter`
- Updated file paths to remove leading slashes for consistency

## Changes
- **appsettings.Development.json**
  - Changed `"path": "/logs/log-.txt"` to `"path": "logs/log-.txt"`
  - Corrected `"rolingInterval": "Day"` to `"rollingInterval": "Day"`
  - Corrected `"roleOnFileSizeLimit": true` to `"rollOnFileSizeLimit": true`
  - Corrected `"formater": "Serilog.Formatting.Json.JsonFormatter"` to `"formatter": "Serilog.Formatting.Json.JsonFormatter"`

- **appsettings.json**
  - Changed `"path": "/logs/log-.txt"` to `"path": "logs/log-.txt"`
  - Corrected `"rolingInterval": "Day"` to `"rollingInterval": "Day"`
  - Corrected `"roleOnFileSizeLimit": true` to `"rollOnFileSizeLimit": true`
  - Corrected `"formater": "Serilog.Formatting.Compact.CompactJsonFormatter"` to `"formatter": "Serilog.Formatting.Compact.CompactJsonFormatter"`
