### PR TITLE
Enable nullable context to resolve nullable reference type issue

### DIFF
--- a/src/SwiftLink.Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/SwiftLink.Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -1,4 +1,6 @@
-﻿using MediatR;
+﻿#nullable enable
+
+using MediatR;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using SwiftLink.Domain.Common;
 


### PR DESCRIPTION
This fix ensures the code follows C#'s nullable reference type conventions and avoids potential issues with nullable annotations in the codebase.